### PR TITLE
Added an SMS Events Network Manager + modifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,8 +42,9 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.gms:play-services-maps:17.0.0'
-    implementation 'com.github.d-u-d-e:network-dictionary:interfaces-v1.1'
+    //implementation 'com.github.d-u-d-e:network-dictionary:interfaces-v1.1'
     implementation 'androidx.room:room-runtime:2.2.3'
+    implementation 'com.github.EIS0:network-dictionary:v0.2'
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:2.28.2'

--- a/app/src/main/java/com/eis/geoCalendar/gps/GPSPosition.java
+++ b/app/src/main/java/com/eis/geoCalendar/gps/GPSPosition.java
@@ -13,7 +13,8 @@ import com.google.android.gms.maps.model.LatLng;
  *
  * @author someone from group 4
  * @author Giorgia Bortoletti
- * @author Niccolò Turcato (just some tweaking)
+ * @author Niccolò Turcato (some tweaking, including stealing code from De Zen)
+ * @author Riccardo De Zen (his code for GPSPosition -> String, String -> GPSPosition was brutally stolen)
  */
 public class GPSPosition {
     private Location mLocation = new Location(GPS_POSITION);

--- a/app/src/main/java/com/eis/geoCalendar/gps/GPSPosition.java
+++ b/app/src/main/java/com/eis/geoCalendar/gps/GPSPosition.java
@@ -19,6 +19,7 @@ public class GPSPosition {
     private Location mLocation = new Location(GPS_POSITION);
 
     private static final String GPS_POSITION = "GPSPosition";
+    private static final String POSITION_SPLIT_SEQUENCE = "ç";
 
     /**
      * Default constructor
@@ -58,6 +59,27 @@ public class GPSPosition {
         mLocation = new Location(GPS_POSITION); //provider name is unnecessary
         mLocation.setLatitude(location.latitude);
         mLocation.setLongitude(location.longitude);
+    }
+
+    /**
+     * Constructor taking a {@link String} as a parameter. The {@code String} should be formatted
+     * as {@link GPSPosition#toString()} does.
+     *
+     * @param locationString The Non-null properly formatted {@link String}.
+     * @throws ArrayIndexOutOfBoundsException If {@code locationString} is not divided in at
+     *                                        least two parts by
+     *                                        {@link GPSPosition#POSITION_SPLIT_SEQUENCE}.
+     * @throws NumberFormatException          If {@code locationString} is not divided into parts
+     *                                        that
+     *                                        are parsable as Double values.
+     */
+    public GPSPosition(@NonNull String locationString) throws
+            ArrayIndexOutOfBoundsException,
+            NumberFormatException {
+        this(
+                Double.parseDouble(locationString.split(POSITION_SPLIT_SEQUENCE)[0]),
+                Double.parseDouble(locationString.split(POSITION_SPLIT_SEQUENCE)[1])
+        );
     }
 
     /**
@@ -116,5 +138,19 @@ public class GPSPosition {
     @Override
     public boolean equals(@Nullable Object obj) {
         return equals(obj, 0);
+    }
+
+    /**
+     * Returns a {@link String} representation of this {@link GPSPosition}. This {@code String} is
+     * considered valid when provided to {@link GPSPosition#GPSPosition(String)}.
+     * More precisely, the String will be in the format:
+     * [latitude]{@link GPSPosition#POSITION_SPLIT_SEQUENCE}[longitude]
+     *
+     * @return A {@link String} representing this {@link GPSPosition}.
+     */
+    @NonNull
+    @Override
+    public String toString() {
+        return getLatitude() + POSITION_SPLIT_SEQUENCE + getLongitude();
     }
 }

--- a/app/src/main/java/com/eis/geoCalendar/network/EventNetworkManager.java
+++ b/app/src/main/java/com/eis/geoCalendar/network/EventNetworkManager.java
@@ -16,5 +16,5 @@ import java.util.ArrayList;
  * @author Luca Crema
  * @since 28/12/2019
  */
-public interface EventNetworkManager<E extends NetworkEvent, P extends Peer> extends NetworkManager<GPSPosition, ArrayList<E>, P, FailReason> {
+public interface EventNetworkManager<E extends NetworkEvent, P extends Peer, F extends FailReason> extends NetworkManager<GPSPosition, ArrayList<E>, P, F> {
 }

--- a/app/src/main/java/com/eis/geoCalendar/network/SMS/ListenerAdapters/GetResourceListenerAdapter.java
+++ b/app/src/main/java/com/eis/geoCalendar/network/SMS/ListenerAdapters/GetResourceListenerAdapter.java
@@ -1,0 +1,60 @@
+package com.eis.geoCalendar.network.SMS.ListenerAdapters;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.listeners.GetResourceListener;
+import com.eis.geoCalendar.gps.GPSPosition;
+import com.eis.geoCalendar.network.SMS.SMSStringEvent;
+import com.eis.smsnetwork.SMSFailReason;
+
+import java.util.ArrayList;
+
+/**
+ * Adapter class for interfaces GetResourceListener<String, String, SMSFailReason> and
+ * GetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason>
+ * <p>
+ * You can consider this as a fake listeners used to access the real one
+ *
+ * @author Turcato
+ */
+public class GetResourceListenerAdapter implements GetResourceListener<String, String, SMSFailReason> {
+    private GetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason> getResourceListener;
+
+    /**
+     * Constructor that fully initializes the object
+     *
+     * @param getResourceListener An object implementing GetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason>
+     */
+    public GetResourceListenerAdapter(@NonNull GetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason> getResourceListener) {
+        this.getResourceListener = getResourceListener;
+    }
+
+    /**
+     * Calls the "real" listener {@link GetResourceListener#onGetResource} method
+     *
+     * @param key   The key of the event, must be a {@link String} obtained by {@link GPSPosition#toString()}
+     * @param value Value of the resource, which is the event's description
+     */
+    @Override
+    public void onGetResource(String key, String value) {
+        GPSPosition position = new GPSPosition(key);
+        //The interface GetResourceListener doesn't retrieve the SMSPeer, can't access that
+        SMSStringEvent event = new SMSStringEvent(position, value, null);
+        ArrayList<SMSStringEvent> eventArrayList = new ArrayList<>();
+        eventArrayList.add(event);
+
+        getResourceListener.onGetResource(position, eventArrayList);
+    }
+
+    /**
+     * Calls the "real" listener {@link GetResourceListener#onGetResourceFailed} method
+     *
+     * @param key    The key of the event, must be a {@link String} obtained by {@link GPSPosition#toString()}
+     * @param reason The reason of the operation's fail
+     */
+    @Override
+    public void onGetResourceFailed(String key, SMSFailReason reason) {
+        GPSPosition position = new GPSPosition(key);
+        getResourceListener.onGetResourceFailed(position, reason);
+    }
+}

--- a/app/src/main/java/com/eis/geoCalendar/network/SMS/ListenerAdapters/RemoveResourceListenerAdapter.java
+++ b/app/src/main/java/com/eis/geoCalendar/network/SMS/ListenerAdapters/RemoveResourceListenerAdapter.java
@@ -1,0 +1,49 @@
+package com.eis.geoCalendar.network.SMS.ListenerAdapters;
+
+import com.eis.communication.network.listeners.RemoveResourceListener;
+import com.eis.geoCalendar.gps.GPSPosition;
+import com.eis.smsnetwork.SMSFailReason;
+
+/**
+ * Adapter class for interfaces RemoveResourceListener<String, SMSFailReason>> and
+ * RemoveResourceListener<GPSPosition, SMSFailReason> removeResourceListener
+ * <p>
+ * You can consider this as a fake listeners used to access the real one
+ *
+ * @author Turcato
+ */
+public class RemoveResourceListenerAdapter implements RemoveResourceListener<String, SMSFailReason> {
+    private RemoveResourceListener<GPSPosition, SMSFailReason> removeResourceListener;
+
+    /**
+     * Constructor that fully initializes the object
+     *
+     * @param removeResourceListener An object implementing RemoveResourceListener<GPSPosition, SMSFailReason>
+     */
+    public RemoveResourceListenerAdapter(RemoveResourceListener<GPSPosition, SMSFailReason> removeResourceListener) {
+        this.removeResourceListener = removeResourceListener;
+    }
+
+    /**
+     * Calls the "real" listener {@link RemoveResourceListener#onResourceRemoved} method
+     *
+     * @param key The Resource's key (the resource is an event in this case)
+     */
+    @Override
+    public void onResourceRemoved(String key) {
+        GPSPosition position = new GPSPosition(key);
+        removeResourceListener.onResourceRemoved(position);
+    }
+
+    /**
+     * Calls the "real" listener {@link RemoveResourceListener#onResourceRemoveFail} method
+     *
+     * @param key    The Resource's key (the resource is an event in this case)
+     * @param reason The reason of the operation's fail
+     */
+    @Override
+    public void onResourceRemoveFail(String key, SMSFailReason reason) {
+        GPSPosition position = new GPSPosition(key);
+        removeResourceListener.onResourceRemoveFail(position, reason);
+    }
+}

--- a/app/src/main/java/com/eis/geoCalendar/network/SMS/ListenerAdapters/SetResourceListenerAdapter.java
+++ b/app/src/main/java/com/eis/geoCalendar/network/SMS/ListenerAdapters/SetResourceListenerAdapter.java
@@ -1,0 +1,67 @@
+package com.eis.geoCalendar.network.SMS.ListenerAdapters;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.listeners.SetResourceListener;
+import com.eis.geoCalendar.gps.GPSPosition;
+import com.eis.geoCalendar.network.SMS.SMSNetworkEventUser;
+import com.eis.geoCalendar.network.SMS.SMSStringEvent;
+import com.eis.smsnetwork.SMSFailReason;
+
+import java.util.ArrayList;
+
+/**
+ * Adapter class for interfaces SetResourceListener<String, String, SMSFailReason> and
+ * SetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason>
+ * <p>
+ * You can consider this as a fake listeners used to access the real one
+ *
+ * @author Turcato
+ */
+public class SetResourceListenerAdapter implements SetResourceListener<String, String, SMSFailReason> {
+    private SetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason> setResourceListener;
+    private SMSNetworkEventUser myself;
+
+    /**
+     * Constructor that fully initializes the object
+     *
+     * @param setResourceListener An object implementing SetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason>
+     */
+    public SetResourceListenerAdapter(@NonNull SetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason> setResourceListener,
+                                      @NonNull SMSNetworkEventUser myself) {
+        this.setResourceListener = setResourceListener;
+        this.myself = myself;
+    }
+
+    /**
+     * Calls the "real" listener {@link SetResourceListener#onResourceSet} method
+     *
+     * @param key   The key of the event, must be a {@link String} obtained by {@link GPSPosition#toString()}
+     * @param value Value of the resource, which is the event's description
+     */
+    @Override
+    public void onResourceSet(String key, String value) {
+        GPSPosition position = new GPSPosition(key);
+        SMSStringEvent event = new SMSStringEvent(position, value, myself);
+        ArrayList<SMSStringEvent> eventArrayList = new ArrayList<>();
+        eventArrayList.add(event);
+
+        setResourceListener.onResourceSet(position, eventArrayList);
+    }
+
+    /**
+     * Calls the "real" listener {@link SetResourceListener#onResourceSetFail} method
+     *
+     * @param key    The key of the event, must be a {@link String} obtained by {@link GPSPosition#toString()}
+     * @param reason The reason of the operation's fail
+     */
+    @Override
+    public void onResourceSetFail(String key, String value, SMSFailReason reason) {
+        GPSPosition position = new GPSPosition(key);
+        SMSStringEvent event = new SMSStringEvent(position, value, myself);
+        ArrayList<SMSStringEvent> eventArrayList = new ArrayList<>();
+        eventArrayList.add(event);
+
+        setResourceListener.onResourceSetFail(position, eventArrayList, reason);
+    }
+}

--- a/app/src/main/java/com/eis/geoCalendar/network/SMS/SMSEventNetworkManager.java
+++ b/app/src/main/java/com/eis/geoCalendar/network/SMS/SMSEventNetworkManager.java
@@ -1,0 +1,91 @@
+package com.eis.geoCalendar.network.SMS;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.NetworkManager;
+import com.eis.communication.network.listeners.GetResourceListener;
+import com.eis.communication.network.listeners.InviteListener;
+import com.eis.communication.network.listeners.RemoveResourceListener;
+import com.eis.communication.network.listeners.SetResourceListener;
+import com.eis.geoCalendar.gps.GPSPosition;
+import com.eis.geoCalendar.network.EventNetworkManager;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.SMSFailReason;
+import com.eis.smsnetwork.SMSNetworkManager;
+
+import java.util.ArrayList;
+
+/**
+ * Simple network manager for {@link SMSStringEvent}s that uses {@link SMSStringEventNetworkManagerAdapter}
+ * as network. Uses Singleton Design pattern since {@link SMSStringEventNetworkManagerAdapter} is a singleton
+ *
+ * @author Turcato
+ */
+public class SMSEventNetworkManager implements EventNetworkManager<SMSStringEvent, SMSPeer, SMSFailReason> {
+    private static SMSEventNetworkManager instance;
+
+    private NetworkManager<GPSPosition, ArrayList<SMSStringEvent>, SMSPeer, SMSFailReason> smsNetworkManager;
+
+    /**
+     * Private constructor since this class uses Singleton DP
+     *
+     * @param appContext The application's context
+     * @param myUser     The user of the current Device
+     */
+    private SMSEventNetworkManager(@NonNull Context appContext, @NonNull SMSNetworkEventUser myUser) {
+        SMSNetworkManager manager = new SMSNetworkManager();
+        manager.setup(appContext.getApplicationContext());
+        smsNetworkManager = SMSStringEventNetworkManagerAdapter.getInstance(appContext, myUser);
+    }
+
+    /**
+     * @param appContext The application's context
+     * @param myUser     The user of the current Device
+     * @return The only instance the device is allowed to access
+     */
+    public static SMSEventNetworkManager getInstance(Context appContext, SMSNetworkEventUser myUser) {
+        if (instance == null)
+            return instance = new SMSEventNetworkManager(appContext, myUser);
+        else
+            return instance;
+    }
+
+    /**
+     * @param key                    The key of the Resource (event) to remove
+     * @param removeResourceListener A listener that waits for the removal of the resource
+     */
+    @Override
+    public void removeResource(GPSPosition key, RemoveResourceListener<GPSPosition, SMSFailReason> removeResourceListener) {
+        smsNetworkManager.removeResource(key, removeResourceListener);
+    }
+
+    /**
+     * @param key                 The key of the Resource (event) to add
+     * @param value               A list of resources (events), identified by the given key, to add
+     * @param setResourceListener A listener that waits for the resource to be added
+     */
+    @Override
+    public void setResource(GPSPosition key, ArrayList<SMSStringEvent> value, SetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason> setResourceListener) {
+        smsNetworkManager.setResource(key, value, setResourceListener);
+    }
+
+    /**
+     * @param key                 The key of the Resource (event) to retrieve
+     * @param getResourceListener A listener that waits for the resource to be retrieved
+     */
+    @Override
+    public void getResource(GPSPosition key, GetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason> getResourceListener) {
+        smsNetworkManager.getResource(key, getResourceListener);
+    }
+
+    /**
+     * @param peer           The {@link com.eis.smslibrary.SMSPeer} to invite
+     * @param inviteListener A listener that waits for the response of the peer
+     */
+    @Override
+    public void invite(SMSPeer peer, InviteListener<SMSPeer, SMSFailReason> inviteListener) {
+        smsNetworkManager.invite(peer, inviteListener);
+    }
+}

--- a/app/src/main/java/com/eis/geoCalendar/network/SMS/SMSStringEventNetworkManagerAdapter.java
+++ b/app/src/main/java/com/eis/geoCalendar/network/SMS/SMSStringEventNetworkManagerAdapter.java
@@ -42,6 +42,7 @@ public class SMSStringEventNetworkManagerAdapter implements NetworkManager<GPSPo
     private SMSStringEventNetworkManagerAdapter(@NonNull Context appContext, @NonNull SMSNetworkEventUser myself) {
         smsNetworkManager = new SMSNetworkManager();
         smsNetworkManager.setup(appContext.getApplicationContext());
+        this.myself = myself;
     }
 
     /**

--- a/app/src/main/java/com/eis/geoCalendar/network/SMS/SMSStringEventNetworkManagerAdapter.java
+++ b/app/src/main/java/com/eis/geoCalendar/network/SMS/SMSStringEventNetworkManagerAdapter.java
@@ -1,0 +1,102 @@
+package com.eis.geoCalendar.network.SMS;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.eis.communication.network.NetworkManager;
+import com.eis.communication.network.listeners.GetResourceListener;
+import com.eis.communication.network.listeners.InviteListener;
+import com.eis.communication.network.listeners.RemoveResourceListener;
+import com.eis.communication.network.listeners.SetResourceListener;
+import com.eis.geoCalendar.gps.GPSPosition;
+import com.eis.geoCalendar.network.SMS.ListenerAdapters.GetResourceListenerAdapter;
+import com.eis.geoCalendar.network.SMS.ListenerAdapters.RemoveResourceListenerAdapter;
+import com.eis.geoCalendar.network.SMS.ListenerAdapters.SetResourceListenerAdapter;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smsnetwork.SMSFailReason;
+import com.eis.smsnetwork.SMSNetworkManager;
+
+import java.util.ArrayList;
+
+/**
+ * Simple network manager Adapter for {@link SMSStringEvent}s that uses {@link com.eis.smsnetwork.SMSNetworkManager}
+ * as real network manager. Uses Singleton Design pattern since {@link com.eis.smsnetwork.SMSNetworkManager} is a singleton
+ * <p>
+ * This class was created because of conflicts with the defined interfaces and the available network dictionary's interfaces
+ *
+ * @author Turcato
+ */
+public class SMSStringEventNetworkManagerAdapter implements NetworkManager<GPSPosition, ArrayList<SMSStringEvent>, SMSPeer, SMSFailReason> {
+    private static SMSStringEventNetworkManagerAdapter instance;
+
+    private SMSNetworkManager smsNetworkManager;
+    private SMSNetworkEventUser myself;
+
+    /**
+     * Private constructor since this class uses Singleton DP
+     *
+     * @param appContext The application's context
+     * @param myself     The user of the current Device
+     */
+    private SMSStringEventNetworkManagerAdapter(@NonNull Context appContext, @NonNull SMSNetworkEventUser myself) {
+        smsNetworkManager = new SMSNetworkManager();
+        smsNetworkManager.setup(appContext.getApplicationContext());
+    }
+
+    /**
+     * @param appContext The application's context
+     * @param myself     The user of the current Device
+     * @return The only instance the device is allowed to access
+     */
+    public static SMSStringEventNetworkManagerAdapter getInstance(@NonNull Context appContext, @NonNull SMSNetworkEventUser myself) {
+        if (instance == null)
+            return instance = new SMSStringEventNetworkManagerAdapter(appContext, myself);
+        else
+            return instance;
+    }
+
+    /**
+     * @param key                 The key of the Resource (event) to add
+     * @param value               A list of resources (events), identified by the given key, to add
+     * @param setResourceListener A listener that waits for the resource to be added
+     */
+    @Override
+    public void setResource(GPSPosition key, ArrayList<SMSStringEvent> value, SetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason> setResourceListener) {
+        SetResourceListener<String, String, SMSFailReason> adapterSetResourceListener = new SetResourceListenerAdapter(setResourceListener, myself);
+
+        for (SMSStringEvent event : value) {
+            smsNetworkManager.setResource(key.toString(), event.getContent(), adapterSetResourceListener);
+        }
+
+    }
+
+    /**
+     * @param key                 The key of the Resource (event) to retrieve
+     * @param getResourceListener A listener that waits for the resource to be retrieved
+     */
+    @Override
+    public void getResource(GPSPosition key, GetResourceListener<GPSPosition, ArrayList<SMSStringEvent>, SMSFailReason> getResourceListener) {
+        GetResourceListener<String, String, SMSFailReason> listener = new GetResourceListenerAdapter(getResourceListener);
+        smsNetworkManager.getResource(key.toString(), listener);
+    }
+
+    /**
+     * @param key                    The key of the Resource (event) to remove
+     * @param removeResourceListener A listener that waits for the removal of the resource
+     */
+    @Override
+    public void removeResource(GPSPosition key, RemoveResourceListener<GPSPosition, SMSFailReason> removeResourceListener) {
+        RemoveResourceListener<String, SMSFailReason> listener = new RemoveResourceListenerAdapter(removeResourceListener);
+        smsNetworkManager.removeResource(key.toString(), listener);
+    }
+
+    /**
+     * @param peer           The {@link com.eis.smslibrary.SMSPeer} to invite
+     * @param inviteListener A listener that waits for the response of the peer
+     */
+    @Override
+    public void invite(SMSPeer peer, InviteListener<SMSPeer, SMSFailReason> inviteListener) {
+        smsNetworkManager.invite(peer, inviteListener);
+    }
+}


### PR DESCRIPTION
### Premise
Hi, this pull request contains the code necessary to HOPEFULLY create an Event Network and its associates. Finger crossed.
I had to modify some of the existing code because I found it was not working well with the available Network dictionary. I sincerely HOPE I haven't messed up too much, I did what I considered necessary. Please don't kill me.
Also, I'm sure all of you can give me some advice: if you see something out of order/wrong/completely wrong please tell me, we need to be sure that this stuff works.

### Additions

- Added SMSEventNetworkManager, SMSStringEventNetworkManagerAdapter, together with adapter interfaces for listeners:

      1. GetResourceListenerAdapter

      2. RemoveResourceListenerAdapter

      3. SetResourceListenerAdapter

### Changes

- Modified EventNetworkManager interface because it was needed to make everything work

### Side changes

- Modified GPSPosition, added a constructor that can create a GPSPosition object starting from a String formatted as the GPSPosition.toString method

### Footer
I've stolen from @RicDeZen 's code (GeoPosition), `honk`
![honk-codestealer](https://user-images.githubusercontent.com/56435959/75374791-2d505200-58cd-11ea-9d10-3c27bc9ce203.jpg)

